### PR TITLE
Fix requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
-ldap
+python-ldap
 ldap3
 impacket


### PR DESCRIPTION
It is not possible to install the `ldap` library, you must use `python-ldap` instead : 

![image](https://github.com/p0dalirius/LDAPmonitor/assets/76688185/ac167f80-bf2f-4a8d-ae2b-bb9cb4e6215a)
