### PR TITLE
[bug] Fixes imports from sectools and flattens nested lists in all_ldap_attributes

### DIFF
--- a/python/pyLDAPmonitor.py
+++ b/python/pyLDAPmonitor.py
@@ -18,6 +18,7 @@ import time
 import datetime
 import re
 from binascii import unhexlify
+from itertools import chain
 
 
 ### Data utils
@@ -129,6 +130,7 @@ class LDAPConsole(object):
         # Add all attributes
         self.all_ldap_attributes.append(ldap3.ALL_ATTRIBUTES)
         # Remove duplicates
+        self.all_ldap_attributes = list(chain.from_iterable(self.all_ldap_attributes))
         self.all_ldap_attributes = sorted(list(set(self.all_ldap_attributes)))
         return self.all_ldap_attributes
 

--- a/python/pyLDAPmonitor.py
+++ b/python/pyLDAPmonitor.py
@@ -11,7 +11,7 @@ import sys
 import ssl
 import random
 import ldap3
-from sectools.windows.ldap import raw_ldap_query, init_ldap_session
+from sectools.windows.ldap.ldap import raw_ldap_query, init_ldap_session
 from sectools.windows.crypto import nt_hash, parse_lm_nt_hashes
 from ldap3.protocol.formatters.formatters import format_sid
 import time


### PR DESCRIPTION
This PR has two fixes.  
First, it fixes the following ImportError:

```text
ImportError: cannot import name 'raw_ldap_query' from 'sectools.windows.ldap' (unknown location)
```

I fixed the ldap import from `sectools` to conform to the change made in <https://github.com/p0dalirius/sectools/commit/350b4641fb9099a700e987daf6dd981449b611d5>

Second is the following TypeError:

```text
    self.all_ldap_attributes = sorted(list(set(self.all_ldap_attributes)))
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unhashable type: 'list'
```

It is caused because `entry["lDAPDisplayName"]`  returns a list containing a single value.  
I flattened the nested list `self.all_ldap_attributes` to avoid the above error.

Without LDAPS, the script still has issues because `sectools` has not been updated to account for `session_security` parameter introduced in <https://github.com/cannatag/ldap3/pull/1042> etc.